### PR TITLE
Add support for the count endpoint.

### DIFF
--- a/src/Webmentions.php
+++ b/src/Webmentions.php
@@ -1,28 +1,41 @@
 <?php
 
 namespace Mattrothenberg\Webmentions;
+
 use GuzzleHttp\Client;
 
 class Webmentions extends \Statamic\Tags\Tags
 {
-    public function index () {
-        $url = $this->params->get('url');
-
-        if (!$url) {
+    public function index()
+    {
+        if (!$this->params->get('url')) {
             return false;
-        } else {
-            $client = new Client([
-                'base_uri' => 'https://webmention.io/'
-            ]);
-            $res = $client->request('GET', '/api/mentions.jf2', [
-                'query' => ['target' => $url],
-                'http_errors' => false
-            ]);
-            $json = json_decode($res->getBody(), true);
-
-            $children = $json['children'];
-
-            return $children ? ['mentions' => $children] : [];
         }
+
+        $json = $this->fetch('/api/mentions.jf2');
+        $children = $json['children'];
+        return $children ? ['mentions' => $children] : [];
+    }
+
+    public function count()
+    {
+        if (!$this->params->get('url')) {
+            return false;
+        }
+
+        return $this->fetch('/api/count');
+    }
+    
+    private function fetch(string $endpoint): array
+    {
+        $client = new Client([
+            'base_uri' => 'https://webmention.io/'
+        ]);
+        $res = $client->request('GET', $endpoint, [
+            'query' => ['target' => $this->params->get('url')],
+            'http_errors' => false
+        ]);
+
+        return json_decode($res->getBody(), true);
     }
 }


### PR DESCRIPTION
This adds support for the `/api/count` endpoint if users are just interested in displaying counts:

```
{{ webmentions:count url="https://example.com" }}
  Total: {{ count }}
  Likes: {{ type:link }}
{{ /webmentions:count }}
```
